### PR TITLE
Fixes #23: Composer won't update in Vagrant

### DIFF
--- a/puppet/modules/symfony-rest/manifests/init.pp
+++ b/puppet/modules/symfony-rest/manifests/init.pp
@@ -13,7 +13,7 @@ class symfony-rest {
     }
 
     package {
-        [ 'git', 'make', 'vim', 'wget', 'curl', 'augeas-tools', 'libaugeas-dev', 'libaugeas-ruby', 'bash-completion', 'libicu48', 'libicu-dev']:
+        [ 'git', 'make', 'vim', 'wget', 'curl', 'augeas-tools', 'libaugeas-dev', 'libaugeas-ruby', 'bash-completion', 'libicu48', 'libicu-dev', 'php5-intl']:
         ensure => present,
         require => File["dotdeb.list"]
     }


### PR DESCRIPTION
The php5-intl extension was a missing dependency; which caused the
Vagrant install command to fail. By adding it to the provisioning
script this will install it and composer runs as expected.
